### PR TITLE
Fix filter meta bug and pagination defaults

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -77,16 +78,24 @@ WSGI_APPLICATION = 'config.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME':'bookspace_db',
-        'USER':'postgres',
-        'PASSWORD':'784512369',
-        'HOST':'localhost',
-        'Port':'5432'
+if os.environ.get("USE_SQLITE"):
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': BASE_DIR / 'db.sqlite3',
+        }
     }
-}
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': 'bookspace_db',
+            'USER': 'postgres',
+            'PASSWORD': '784512369',
+            'HOST': 'localhost',
+            'Port': '5432',
+        }
+    }
 
 
 # Password validation

--- a/core/filters.py
+++ b/core/filters.py
@@ -2,10 +2,10 @@ import django_filters
 from .models import Book
 
 class BookFilter(django_filters.FilterSet):
-    title = django_filters.CharFilter(lookup_expr='icontains')
-    author = django_filters.CharFilter(lookup_expr='icontains')
+    title = django_filters.CharFilter(lookup_expr="icontains")
+    author = django_filters.CharFilter(lookup_expr="icontains")
     available = django_filters.BooleanFilter()
-    
-    class meta:
+
+    class Meta:
         model = Book
-        fields = ['title','author','avialable']
+        fields = ["title", "author", "available"]

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,24 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
-# Create your tests here.
+from .filters import BookFilter
+from .models import Book
+from .views import BookPagination
+
+
+@override_settings(DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}})
+class BookFilterTests(TestCase):
+    def test_filter_meta_model(self):
+        self.assertEqual(BookFilter.Meta.model, Book)
+
+    def test_filter_fields(self):
+        self.assertListEqual(
+            BookFilter.Meta.fields,
+            ["title", "author", "available"],
+        )
+
+
+@override_settings(DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}})
+class PaginationTests(TestCase):
+    def test_page_size_integer(self):
+        self.assertEqual(BookPagination.page_size, 5)
+

--- a/core/views.py
+++ b/core/views.py
@@ -6,12 +6,13 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters
 from .filters import BookFilter
 
-class Bookpagination(PageNumberPagination):
-    page_size='5'
+class BookPagination(PageNumberPagination):
+    page_size = 5
+
 class BookListCreateAPIView(generics.ListCreateAPIView):
     queryset = Book.objects.all()
     serializer_class = BookSerializer
-    pagination_class = Bookpagination
+    pagination_class = BookPagination
     filter_backends = [DjangoFilterBackend , filters.OrderingFilter, filters.SearchFilter]
     filterset_class = BookFilter
     search_fields = ['title','author']


### PR DESCRIPTION
## Summary
- fix missing `Meta` class in `BookFilter`
- correct pagination class name and numeric page_size
- add basic tests for filter config and pagination
- allow switching to SQLite via `USE_SQLITE` env var for tests

## Testing
- `USE_SQLITE=1 python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68401613e4288329b4486b8c6dac13a5