### PR TITLE
Fix PostgreSQL port config

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -93,7 +93,7 @@ else:
             'USER': 'postgres',
             'PASSWORD': '784512369',
             'HOST': 'localhost',
-            'Port': '5432',
+            'PORT': '5432',
         }
     }
 


### PR DESCRIPTION
## Summary
- fix key for PostgreSQL port in settings

## Testing
- `USE_SQLITE=1 python manage.py makemigrations`
- `USE_SQLITE=1 python manage.py migrate`


------
https://chatgpt.com/codex/tasks/task_e_68405096223483299b91cbf8e64bc2a5