### PR TITLE
Fix gitignore for Python bytecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-__pycache__/
-*.py[cod]
+**/__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary
- ensure Python bytecode isn't tracked

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68405375f1408329bbcb823747673df5