### PR TITLE
Default tests to sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ python manage.py migrate
 # Run the development server
 python manage.py runserver
 
+# Run tests (uses SQLite by default)
+python manage.py test
+
+Running tests automatically sets the `USE_SQLITE` environment variable to `1`,
+so SQLite is used for test databases. Unset this variable if you prefer running
+tests against PostgreSQL.
+
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 ## 📚 Core API Endpoints

--- a/manage.py
+++ b/manage.py
@@ -3,6 +3,10 @@
 import os
 import sys
 
+# Automatically use SQLite database when running tests
+if 'test' in sys.argv:
+    os.environ.setdefault('USE_SQLITE', '1')
+
 
 def main():
     """Run administrative tasks."""


### PR DESCRIPTION
## Summary
- use SQLite by default when running tests
- document default SQLite test behavior in README

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68405379962883298975fc27d6167c0f